### PR TITLE
Feature: Add Leaderboard Page Button to Dashboard

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,7 @@ import Kanban from "./Kanban";
 import Register from "./pages/Register";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
+import LeaderboardPage from "./pages/LeaderboardPage";
 import Navbar from "./components/Navbar";
 
 //  Route Guard using localStorage
@@ -24,6 +25,7 @@ function App() {
           <Route path="/register" element={<Register />} />
           <Route path="/login" element={<Login />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/leaderboard" element={<LeaderboardPage />} />
 
           {/* Kanban route - no longer protected */}
           <Route

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -57,12 +57,20 @@ const Dashboard = () => {
       <div className="max-w-7xl mx-auto">
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-3xl font-bold text-gray-800">Dashboard</h1>
-          <a 
-            href="/kanban" 
-            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200"
-          >
-            Go to Kanban Board
-          </a>
+          <div className="flex gap-2">
+            <a 
+              href="/leaderboard" 
+              className="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded transition duration-200"
+            >
+              View Full Leaderboard
+            </a>
+            <a 
+              href="/kanban" 
+              className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200"
+            >
+              Go to Kanban Board
+            </a>
+          </div>
         </div>
         
         {/* Stats Cards */}

--- a/client/src/pages/LeaderboardPage.jsx
+++ b/client/src/pages/LeaderboardPage.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import Leaderboard from "../components/Leaderboard";
+import { Link } from "react-router-dom";
+
+const LeaderboardPage = () => {
+  return (
+    <div className="min-h-screen bg-gray-100 p-6">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-3xl font-bold text-gray-800">Contributor Leaderboard</h1>
+          <Link 
+            to="/dashboard" 
+            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200"
+          >
+            Back to Dashboard
+          </Link>
+        </div>
+        
+        <Leaderboard />
+      </div>
+    </div>
+  );
+};
+
+export default LeaderboardPage;


### PR DESCRIPTION
Close : #16 

### Problem
Users had to view the leaderboard only within the dashboard page, without a dedicated page for the leaderboard. There was no direct navigation to a full leaderboard view.

### Solution
This PR adds a dedicated leaderboard page with the following enhancements:
1. Created a new LeaderboardPage.jsx component that displays the leaderboard in a full-page view
2. Added a "View Full Leaderboard" button to the dashboard for easy navigation
3. Updated routing in App.jsx to include the new leaderboard route

### How it fixes the issue
This implementation improves user experience by providing:
- A dedicated page for the leaderboard, allowing users to focus on contributor rankings
- Easy navigation between the dashboard and leaderboard pages
- A cleaner dashboard layout with the option to view the full leaderboard separately