### PR TITLE
Add CODE_OF_CONDUCT.md based on Contributor Covenant v2.1

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Contributor Covenant Code of Conduct (v2.1)
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our project and community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of **expected behavior**:
+
+- Use welcoming and inclusive language
+- Be respectful of differing viewpoints and experiences
+- Gracefully accept constructive criticism
+- Focus on what is best for the community
+- Show empathy towards other community members
+
+Examples of **unacceptable behavior**:
+
+- Harassment, intimidation, or discriminatory comments
+- Public or private insults or attacks
+- Publishing others’ private information without permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Reporting Guidelines
+
+If you are subject to or witness unacceptable behavior, please report it by contacting [INSERT EMAIL HERE]. All reports will be reviewed and investigated and will remain confidential.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+


### PR DESCRIPTION
This PR adds a CODE_OF_CONDUCT.md file based on Contributor Covenant v2.1 to define:
- Expected behavior
- Unacceptable behavior
- Reporting guidelines
- Maintainer responsibilities

It helps maintain a welcoming and inclusive environment for all contributors.
