### PR TITLE
Add GitHub Issue Forms (Bug, Feature, Documentation)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: "🐞 Bug Report"
+description: Report a bug to help us improve
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of the issue.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the steps to reproduce this bug.
+      placeholder: |
+        1. Go to...
+        2. Click on...
+        3. Scroll to...
+        4. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen instead?
+      placeholder: Expected output...
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add screenshots, logs, or any other useful info.
+

--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -1,0 +1,34 @@
+name: "📘 Documentation Update"
+description: Request an improvement or fix in documentation
+labels: ["documentation"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page / Section to Update
+      description: Which doc page needs improvement?
+      placeholder: docs/setup.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: changes
+    attributes:
+      label: Suggested Changes
+      description: Describe what needs to be added or fixed.
+      placeholder: This section is unclear because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason / Benefit
+      description: Why is this update important?
+      placeholder: This will help contributors understand...
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Notes
+      description: Any extra references or links.

--- a/.github/ISSUE_TEMPLATE/feature_report.yml
+++ b/.github/ISSUE_TEMPLATE/feature_report.yml
@@ -1,0 +1,34 @@
+name: "💡 Feature Request"
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: Explain the problem your feature would solve.
+      placeholder: The issue I'm facing is...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature you want.
+      placeholder: I suggest that we...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Mention other approaches you thought of.
+      placeholder: Another way to solve this could be...
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Details
+      description: Add references or examples if available.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Which issue does this PR close?
+
+<!--
+We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
+-->
+
+- Closes #.
+
+## Rationale for this change
+
+<!--
+ Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
+ Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
+-->
+
+## What changes are included in this PR?
+
+<!--
+There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
+-->
+
+## Are these changes tested?
+
+<!--
+We typically require tests for all PRs in order to:
+1. Prevent the code from being accidentally broken by subsequent changes
+2. Serve as another way to document the expected behavior of the code
+
+If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
+-->
+
+## Are there any user-facing changes?
+
+<!--
+If there are user-facing changes then we may require documentation to be updated before approving the PR.
+-->
+
+<!--
+If there are any breaking changes to public APIs, please add the `api change` label.
+-->


### PR DESCRIPTION
This PR adds three GitHub Issue Forms to improve the quality and structure of new issues:

Issue Fixes: #21 

- .github/ISSUE_TEMPLATE/bug_report.yml
- .github/ISSUE_TEMPLATE/feature_request.yml
- .github/ISSUE_TEMPLATE/documentation_update.yml

### Why YAML instead of Markdown?
YAML enables GitHub's new interactive Issue Forms, which provide:
- Required fields
- Clear placeholders
- Better formatting
- More consistent issue submissions
Markdown templates don't support required fields or form-style inputs, so YAML gives a more professional and guided issue experience.

And also add pull_request_template.md 

No project code was changed — only repository metadata.
