### PR TITLE
Fix: Website name not properly displayed in meta head

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>LearnSpace - Task & Learning Management System</title>
     <link href="/src/style.css" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
### Description
The website name is not properly configured in the HTML meta head section. Currently, the title tag shows "Vite + React" instead of the actual project name "LearnSpace". This affects SEO and the tab display in browsers.

Close : #33 