### PR TITLE
Fix: Kanban page not functioning - Route points to TaskManager instea…

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import About from "./pages/About";
 
 import Whiteboard from "./components/Whiteboard"; // Added Whiteboard import
 import TaskManager from "./components/TaskManager"; // Added TaskManager import
+import Kanban from "./Kanban"; // Added Kanban import
 
 //  Route Guard using localStorage
 const ProtectedRoute = ({ children }) => {
@@ -44,12 +45,12 @@ function App() {
           }
         />
 
-        {/* Task Manager route */}
+        {/* Kanban route */}
         <Route
           path="/kanban"
           element={
             <ProtectedRoute>
-              <TaskManager />
+              <Kanban />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/Kanban.jsx
+++ b/frontend/src/Kanban.jsx
@@ -220,7 +220,7 @@ const Kanban = () => {
                   ))}
 
                   {tasks.filter((task) => task.status === status).map((task, index) => (
-                    <Draggable key={task._id} draggableId={task._id} index={index + 10}>
+                    <Draggable key={task._id} draggableId={task._id} index={index}>
                       {(provided) => (
                         <div
                           ref={provided.innerRef}


### PR DESCRIPTION
### • Description: 
The Kanban page is not working as expected because the route `/kanban` in App.jsx was pointing to TaskManager component instead of the actual Kanban component. The Kanban component has drag-and-drop functionality but was not accessible through the current routing. Also fixed an issue with draggable index in the Kanban component that could cause drag and drop problems.


Close : #92 
